### PR TITLE
UpdateStatuses: Fix KeyError in mark_being_updated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.0.3
+-----
+
+* Fixed unhandled KeyError in UpdateStatuses.
+
 1.0.2
 -----
 

--- a/memoize/statuses.py
+++ b/memoize/statuses.py
@@ -31,6 +31,8 @@ class UpdateStatuses:
         self._updates_in_progress[key] = future
 
         def complete_on_timeout_passed():
+            if key not in self._updates_in_progress:
+                return
             if self._updates_in_progress[key] == future and not self._updates_in_progress[key].done():
                 self.logger.debug('Update task timed out - notifying clients awaiting for key %s', key)
                 self._updates_in_progress[key].set_result(None)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def prepare_description():
 
 setup(
     name='py-memoize',
-    version='1.0.2',
+    version='1.0.3',
     author='Michal Zmuda',
     author_email='zmu.michal@gmail.com',
     url='https://github.com/DreamLab/memoize',


### PR DESCRIPTION
Race condition: complete_on_timeout_passed is still executed even after the update has completed (mark_updated has been called).