### PR TITLE
Fixed parallel queries returning expired entries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.1.1
+-----
+
+* Fixed parallel queries returning expired entries (while expired entry was being refreshed).
+
 1.1.0
 -----
 

--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -137,7 +137,7 @@ def memoize(method: Optional[Callable] = None, configuration: CacheConfiguration
             result = await refresh(current_entry, key, value_future_provider, configuration_snapshot)
         elif current_entry.expires_after <= now:
             logger.debug('Entry expiration reached - entry update (blocking) for key %s', key)
-            result = await refresh(current_entry, key, value_future_provider, configuration_snapshot)
+            result = await refresh(None, key, value_future_provider, configuration_snapshot)
         elif current_entry.update_after <= now:
             logger.debug('Entry update point expired - entry update (async - current entry returned) for key %s', key)
             _call_soon(refresh, current_entry, key, value_future_provider, configuration_snapshot)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def prepare_description():
 
 setup(
     name='py-memoize',
-    version='1.1.0',
+    version='1.1.1',
     author='Michal Zmuda',
     author_email='zmu.michal@gmail.com',
     url='https://github.com/DreamLab/memoize',

--- a/tests/asynciotests/test_wrapper_manually_applied_on_asyncio.py
+++ b/tests/asynciotests/test_wrapper_manually_applied_on_asyncio.py
@@ -1,10 +1,13 @@
+import asyncio
 import time
 from datetime import timedelta
 from unittest.mock import Mock
 
 import tornado
+from tornado.platform.asyncio import to_asyncio_future
 from tornado.testing import AsyncTestCase, gen_test
 
+from memoize import memoize_configuration
 from memoize.configuration import MutableCacheConfiguration, NotConfiguredCacheCalledException, \
     DefaultInMemoryCacheConfiguration
 from memoize.eviction import LeastRecentlyUpdatedEvictionStrategy
@@ -41,11 +44,12 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         await _ensure_asyncio_background_tasks_finished()
         value = 1
-        res2 = await get_value_cached('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = await self._call_thrice(lambda: get_value_cached('test', kwarg='args'))
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(0, res2)
+        self.assertEqual([0, 0, 0], res2)
 
     @gen_test
     async def test_should_return_updated_value_on_expiration_time_reached(self):
@@ -65,11 +69,12 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         await _ensure_asyncio_background_tasks_finished()
         value = 1
-        res2 = await get_value_cached('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = await self._call_thrice(lambda: get_value_cached('test', kwarg='args'))
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(1, res2)
+        self.assertEqual([1, 1, 1], res2)
 
     @gen_test
     async def test_should_return_current_value_on_first_call_after_update_time_reached_but_not_expiration_time(self):
@@ -89,11 +94,12 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         await _ensure_asyncio_background_tasks_finished()
         value = 1
-        res2 = await get_value_cached('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = await self._call_thrice(lambda: get_value_cached('test', kwarg='args'))
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(0, res2)
+        self.assertEqual([0, 0, 0], res2)
 
     @gen_test
     async def test_should_return_current_value_on_second_call_after_update_time_reached_but_not_expiration_time(self):
@@ -115,11 +121,12 @@ class MemoizationTests(AsyncTestCase):
         value = 1
         await get_value_cached('test', kwarg='args')
         await _ensure_asyncio_background_tasks_finished()
-        res2 = await get_value_cached('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = await self._call_thrice(lambda: get_value_cached('test', kwarg='args'))
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(1, res2)
+        self.assertEqual([1, 1, 1], res2)
 
     @gen_test
     async def test_should_return_different_values_on_different_args_with_default_key(self):
@@ -286,3 +293,13 @@ class MemoizationTests(AsyncTestCase):
         # then
         expected = CachedMethodFailedException('Refresh timed out')
         self.assertEqual(str(expected), str(context.exception))  # ToDo: consider better comparision
+
+    @staticmethod
+    async def _call_thrice(call):
+        # gen_test setup somehow interferes with coroutines and futures
+        # code tested manually works without such "decorations" but for testing this workaround was the bes I've found
+        if memoize_configuration.force_asyncio:
+            res2 = await asyncio.gather(call(), call(), call())
+        else:
+            res2 = await asyncio.gather(to_asyncio_future(call()), to_asyncio_future(call()), to_asyncio_future(call()))
+        return res2

--- a/tests/tornadotests/test_wrapper.py
+++ b/tests/tornadotests/test_wrapper.py
@@ -36,11 +36,14 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         yield _ensure_background_tasks_finished()
         value = 1
-        res2 = yield get_value('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = yield [get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'), ]
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(0, res2)
+        self.assertEqual([0, 0, 0], res2)
 
     @gen_test
     def test_should_return_updated_value_on_expiration_time_reached(self):
@@ -58,11 +61,14 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         yield _ensure_background_tasks_finished()
         value = 1
-        res2 = yield get_value('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = yield [get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'), ]
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(1, res2)
+        self.assertEqual([1, 1, 1], res2)
 
     @gen_test
     def test_should_return_current_value_on_first_call_after_update_time_reached_but_not_expiration_time(self):
@@ -80,11 +86,14 @@ class MemoizationTests(AsyncTestCase):
         time.sleep(.200)
         yield _ensure_background_tasks_finished()
         value = 1
-        res2 = yield get_value('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = yield [get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'), ]
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(0, res2)
+        self.assertEqual([0, 0, 0], res2)
 
     @gen_test
     def test_should_return_current_value_on_second_call_after_update_time_reached_but_not_expiration_time(self):
@@ -104,11 +113,14 @@ class MemoizationTests(AsyncTestCase):
         value = 1
         yield get_value('test', kwarg='args')
         yield _ensure_background_tasks_finished()
-        res2 = yield get_value('test', kwarg='args')
+        # calling thrice be more confident about behaviour of parallel execution
+        res2 = yield [get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'),
+                      get_value('test', kwarg='args'), ]
 
         # then
         self.assertEqual(0, res1)
-        self.assertEqual(1, res2)
+        self.assertEqual([1, 1, 1], res2)
 
     @gen_test
     def test_should_return_different_values_on_different_args_with_default_key(self):


### PR DESCRIPTION
 (while expired entry was being refreshed).