### PR TITLE
Fix for `RuntimeError: await wasn't used with future`

### DIFF
--- a/memoize/statuses.py
+++ b/memoize/statuses.py
@@ -57,7 +57,7 @@ class UpdateStatuses:
         update = self._updates_in_progress.pop(key)
         update.set_result(None)
 
-    def await_updated(self, key: CacheKey) -> Awaitable[Optional[CacheEntry]]:
+    async def await_updated(self, key: CacheKey) -> Awaitable[Optional[CacheEntry]]:
         """Waits (asynchronously) until update in progress has benn finished.
         Returns updated entry or None if update failed/timed-out.
         Should be called only if 'is_being_updated' returned True (and since then IO-loop has not been lost)."""


### PR DESCRIPTION
Whole stacktrace looks like
```
2024-04-24T11:54:47.263047179Z stdout F   File "/home/paas/application/lib/memoize/wrapper.py", line 128, in wrapper
2024-04-24T11:54:47.263051198Z stdout F     result = await refresh(current_entry, key, value_future_provider, configuration_snapshot)
2024-04-24T11:54:47.263055379Z stdout F              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-24T11:54:47.263071169Z stdout F   File "/home/paas/application/lib/memoize/wrapper.py", line 73, in refresh
2024-04-24T11:54:47.263075329Z stdout F     entry = await update_statuses.await_updated(key)
2024-04-24T11:54:47.263079169Z stdout F             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-24T11:54:47.263082849Z stdout F RuntimeError: await wasn't used with future
```