### PR TITLE
Add mypy friendly py.typed marker and stubs

### DIFF
--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -17,10 +17,8 @@ from memoize.invalidation import InvalidationSupport
 from memoize.statuses import UpdateStatuses, InMemoryLocks
 
 
-def memoize(method: Optional[Callable] = None,
-            configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None,
-            update_statuses: Optional[UpdateStatuses] = None):
+def memoize(method: Optional[Callable] = None, configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None):
     """Wraps function with memoization.
 
     If entry reaches time it should be updated, refresh is performed in background,

--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -19,7 +19,8 @@ from memoize.statuses import UpdateStatuses, InMemoryLocks
 
 def memoize(method: Optional[Callable] = None,
             configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None):
+            invalidation: Optional[InvalidationSupport] = None,
+            update_statuses: Optional[UpdateStatuses] = None):
     """Wraps function with memoization.
 
     If entry reaches time it should be updated, refresh is performed in background,

--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -17,7 +17,8 @@ from memoize.invalidation import InvalidationSupport
 from memoize.statuses import UpdateStatuses, InMemoryLocks
 
 
-def memoize(method: Optional[Callable] = None, configuration: Optional[CacheConfiguration] = None,
+def memoize(method: Optional[Callable] = None,
+            configuration: Optional[CacheConfiguration] = None,
             invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None):
     """Wraps function with memoization.
 

--- a/memoize/wrapper.pyi
+++ b/memoize/wrapper.pyi
@@ -8,14 +8,10 @@ FN = TypeVar('FN', bound=Callable)
 
 
 @overload
-def memoize(*,
-            configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None,
-            update_statuses: Optional[UpdateStatuses] = None) -> Callable[[FN], FN]: ...
+def memoize(*, configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None) -> Callable[[FN], FN]: ...
 
 
 @overload
-def memoize(method: FN,
-            configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None,
-            update_statuses: Optional[UpdateStatuses] = None) -> FN: ...
+def memoize(method: FN, configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None) -> FN: ...

--- a/memoize/wrapper.pyi
+++ b/memoize/wrapper.pyi
@@ -2,6 +2,7 @@ from typing import Callable, TypeVar, overload, Optional
 
 from memoize.configuration import CacheConfiguration
 from memoize.invalidation import InvalidationSupport
+from memoize.statuses import UpdateStatuses
 
 FN = TypeVar('FN', bound=Callable)
 
@@ -9,10 +10,12 @@ FN = TypeVar('FN', bound=Callable)
 @overload
 def memoize(*,
             configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None) -> Callable[[FN], FN]: ...
+            invalidation: Optional[InvalidationSupport] = None,
+            update_statuses: Optional[UpdateStatuses] = None) -> Callable[[FN], FN]: ...
 
 
 @overload
 def memoize(method: FN,
             configuration: Optional[CacheConfiguration] = None,
-            invalidation: Optional[InvalidationSupport] = None) -> FN: ...
+            invalidation: Optional[InvalidationSupport] = None,
+            update_statuses: Optional[UpdateStatuses] = None) -> FN: ...

--- a/memoize/wrapper.pyi
+++ b/memoize/wrapper.pyi
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, overload
+from typing import Callable, TypeVar, overload, Optional
 
 from memoize.configuration import CacheConfiguration
 from memoize.invalidation import InvalidationSupport
@@ -7,11 +7,12 @@ FN = TypeVar('FN', bound=Callable)
 
 
 @overload
-def memoize(*, configuration: CacheConfiguration = None,
-            invalidation: InvalidationSupport = None) -> Callable[[FN], FN]: ...
+def memoize(*,
+            configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None) -> Callable[[FN], FN]: ...
 
 
 @overload
 def memoize(method: FN,
-            configuration: CacheConfiguration = None,
-            invalidation: InvalidationSupport = None) -> FN: ...
+            configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None) -> FN: ...

--- a/memoize/wrapper.pyi
+++ b/memoize/wrapper.pyi
@@ -7,7 +7,7 @@ FN = TypeVar('FN', bound=Callable)
 
 
 @overload
-def memoize(configuration: CacheConfiguration = None,
+def memoize(*, configuration: CacheConfiguration = None,
             invalidation: InvalidationSupport = None) -> Callable[[FN], FN]: ...
 
 

--- a/memoize/wrapper.pyi
+++ b/memoize/wrapper.pyi
@@ -1,0 +1,17 @@
+from typing import Callable, TypeVar, overload
+
+from memoize.configuration import CacheConfiguration
+from memoize.invalidation import InvalidationSupport
+
+FN = TypeVar('FN', bound=Callable)
+
+
+@overload
+def memoize(configuration: CacheConfiguration = None,
+            invalidation: InvalidationSupport = None) -> Callable[[FN], FN]: ...
+
+
+@overload
+def memoize(method: FN,
+            configuration: CacheConfiguration = None,
+            invalidation: InvalidationSupport = None) -> FN: ...

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     url='https://github.com/DreamLab/memoize',
     maintainer='DreamLab',
     packages=['memoize'],
+    package_data={'memoize': ['py.typed']},
     test_suite='tests',
     license='Apache License 2.0',
     description=('Caching library for asynchronous Python applications (both based on asyncio and Tornado) '


### PR DESCRIPTION
Hey nice lib,

I'm trying to make it "mypy-friendly".


tested on py3.11 with this stub, but it should work for older versions too

```
from memoize.configuration import DefaultInMemoryCacheConfiguration
from memoize.wrapper import memoize


@memoize(configuration=DefaultInMemoryCacheConfiguration())
async def get_value(arg: str, *, kwarg: str = None) -> str:
    return arg + (kwarg or '')

reveal_type(get_value)
```


before would yield 
```
checktypes.py:9: note: Revealed type is "Any"
```


now yields
```
checktypes.py:9: note: Revealed type is "def (arg: builtins.str, *, kwarg: Union[builtins.str, None] =) -> typing.Coroutine[Any, Any, builtins.str]"
```

