### PR TITLE
[#35] Since 3.8, CancelledError is a subclass of BaseException rather…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 -----
 
 * Since 3.8, CancelledError is a subclass of BaseException rather than Exception, so we need to catch it explicitly.
+* Enabled `mypy` for `wrapper` function.
 
 3.1.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+3.1.1
+-----
+
+* Since 3.8, CancelledError is a subclass of BaseException rather than Exception, so we need to catch it explicitly.
+
 3.1.0
 -----
 

--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -6,7 +6,7 @@ import asyncio
 import datetime
 import functools
 import logging
-from asyncio import Future
+from asyncio import Future, CancelledError
 from typing import Optional, Callable
 
 from memoize.configuration import CacheConfiguration, NotConfiguredCacheCalledException, \
@@ -116,7 +116,7 @@ def memoize(method: Optional[Callable] = None, configuration: CacheConfiguration
                 logger.debug('Timeout for %s: %s', key, e)
                 update_statuses.mark_update_aborted(key, e)
                 raise CachedMethodFailedException('Refresh timed out') from e
-            except Exception as e:
+            except (Exception, CancelledError) as e:
                 logger.debug('Error while refreshing cache for %s: %s', key, e)
                 update_statuses.mark_update_aborted(key, e)
                 raise CachedMethodFailedException('Refresh failed to complete') from e

--- a/memoize/wrapper.py
+++ b/memoize/wrapper.py
@@ -17,8 +17,8 @@ from memoize.invalidation import InvalidationSupport
 from memoize.statuses import UpdateStatuses, InMemoryLocks
 
 
-def memoize(method: Optional[Callable] = None, configuration: CacheConfiguration = None,
-            invalidation: InvalidationSupport = None, update_statuses: UpdateStatuses = None):
+def memoize(method: Optional[Callable] = None, configuration: Optional[CacheConfiguration] = None,
+            invalidation: Optional[InvalidationSupport] = None, update_statuses: Optional[UpdateStatuses] = None):
     """Wraps function with memoization.
 
     If entry reaches time it should be updated, refresh is performed in background,
@@ -123,7 +123,7 @@ def memoize(method: Optional[Callable] = None, configuration: CacheConfiguration
 
     @functools.wraps(method)
     async def wrapper(*args, **kwargs):
-        if not configuration.configured():
+        if configuration is None or not configuration.configured():
             raise NotConfiguredCacheCalledException()
 
         configuration_snapshot = MutableCacheConfiguration.initialized_with(configuration)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 no_implicit_optional=False
+check_untyped_defs=True

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def prepare_description():
 
 setup(
     name='py-memoize',
-    version='3.1.0',
+    version='3.1.1',
     author='Michal Zmuda',
     author_email='zmu.michal@gmail.com',
     url='https://github.com/DreamLab/memoize',


### PR DESCRIPTION
… than Exception, so we need to catch it explicitly.